### PR TITLE
Fix 'classy' typo

### DIFF
--- a/examples/interactive/index.html
+++ b/examples/interactive/index.html
@@ -54,7 +54,7 @@
         <p class="lead">
             This example page uses Rocky.js and <a href="http://worrydream.com/Tangle/reference.html">Tangle.js</a> to build interactive code samples of <a href="https://developer.getpebble.com/docs/c/">today's C-API for Pebble</a>. This example uses Rocky.js to ensure pixel-perfect results, and is inspired by <a href="http://worrydream.com/#!2/LadderOfAbstraction">Bret Victor's interactive</a> essays.
         </p>
-        <p class="lead">Scroll down and explore Pebble's classy C-API directly in your browser by clicking and dragging the highlighted elements in the code snippets!</p>
+        <p class="lead">Scroll down and explore Pebble's classic C API directly in your browser by clicking and dragging the highlighted elements in the code snippets!</p>
     </div>
 
 


### PR DESCRIPTION
Also remove an unnecessary hyphen. 