### PR TITLE
Design iteration of CSS

### DIFF
--- a/examples/interactive/index.html
+++ b/examples/interactive/index.html
@@ -60,7 +60,7 @@
 
     <div id="graphics_fill_radial">
         
-        <h3>graphics_fill_radial</h3>
+        <h2>graphics_fill_radial</h2>
         <p><code><a href="https://developer.getpebble.com/docs/c/Graphics/Drawing_Primitives/#graphics_fill_radial">graphics_fill_radial</a></code> fills a circle clockwise between <code>angle_start</code> and <code>angle_end</code>, where 0° is the top of the circle. If the difference between <code>angle_start</code> and <code>angle_end</code> is greater than 360°, a full circle will be drawn and filled. If <code>angle_start</code> is greater than <code>angle_end</code> nothing will be drawn.</p>
     
         <div class="row">

--- a/html/css/style.css
+++ b/html/css/style.css
@@ -1,16 +1,74 @@
-#githubForkLink {
-    background: url(../img/forkBanner.png) no-repeat top right;
-    position: absolute;
-    display: block;
-    width: 149px;
-    height: 149px;
-    top: 0;
-    right: 0;
+@import url(https://fonts.googleapis.com/css?family=Bowlby+One+SC|Roboto:400,700,400italic);
 
-    /* Hide the text. */
-    text-indent: 100%;
-    white-space: nowrap;
-    overflow: hidden;
+body {
+  font: 16px/1.5 'Roboto', sans-serif;
+}
+
+body {
+  padding-bottom: 2em;
+}
+
+body > .container:first-child > .row:first-child > div > p:first-child {
+  display: none;
+}
+
+h1 {
+  font-size: 3em;
+}
+
+h1 + blockquote {
+  border: 0 none;
+  max-width: 600px;
+  text-align: center;
+  margin: 0 auto 3em;
+  padding: 0;
+}
+
+h1, h2 {
+  font-family: "Bowlby One SC";
+  overflow: hidden;
+  text-align: center;
+  margin: 2em 0 1em;
+  text-transform: uppercase;
+}
+
+h1:before, h1:after, h2:before, h2:after {
+  background-color: #ddd;
+  content: "";
+  display: inline-block;
+  height: 1px;
+  position: relative;
+  vertical-align: middle;
+  width: 50%;
+}
+
+h1:before, h2:before {
+  right: 0.5em;
+  margin-left: -50%;
+}
+
+h1:after, h2:after {
+  left: 0.5em;
+  margin-right: -50%;
+}
+
+h3 {
+  margin: 1em 0 0.5em;
+}
+
+#githubForkLink {
+  background: url(../img/forkBanner.png) no-repeat top right;
+  position: absolute;
+  display: block;
+  width: 149px;
+  height: 149px;
+  top: 0;
+  right: 0;
+
+  /* Hide the text. */
+  text-indent: 100%;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 table.table-compatibility>tbody>tr.standard {
@@ -32,4 +90,3 @@ table.table-compatibility>tbody>tr.planned {
 table.table-compatibility>tbody>tr.not-planned {
   background-color: #f2dede
 }
-

--- a/html/markdown/template.html
+++ b/html/markdown/template.html
@@ -19,7 +19,11 @@
 </head>
 <body>
 <div class="container">
-    <%=document%>
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <%=document%>
+        </div>
+    </div>
     <%=github_banner%>
 </div>
 

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,12 @@
 [![Build Status](https://travis-ci.org/pebble/rockyjs.svg?branch=master)](https://travis-ci.org/pebble/rockyjs)
 
 # Rocky.js
-
-Rocky.js is a version of Pebble's firmware that has been [transpiled](https://en.wikipedia.org/wiki/Source-to-source_compiler) to JavaScript, and that can be attached to an HTML canvas. This is our first step towards exploring the possibility of including a JavaScript runtime in our operating system.
+> Pebble's first step towards exploring the possibility of including a JavaScript runtime in Pebble's operating system.
 
 <a class="jsbin-embed" href="///jsbin.com/lojagu/embed?js,output&height=350px">Interactive Rocky.js example on jsbin.com</a>
 <script src="https://static.jsbin.com/js/embed.min.js?3.35.9"></script>
 
-[More examples in this repository](examples/)
+*Rocky.js* is a version of Pebble's firmware that has been [transpiled](https://en.wikipedia.org/wiki/Source-to-source_compiler) to JavaScript, and that can be attached to an HTML canvas. Above you see an example of that (and [even more examples here](examples/)).
 
 ### That's a weird first step!
 
@@ -19,68 +18,70 @@ We're interested in seeing how you approach JavaScript watchface development, as
 
 ### What about Pebble.js?
 
-If you're familiar with Pebble and JavaScript, there's a good chance you may also be familiar with [Pebble.js](https://developer.pebble.com/docs/pebblejs/).
+If you're familiar with Pebble and JavaScript, there's a good chance you may also be familiar with [*Pebble.js*](https://developer.pebble.com/docs/pebblejs/).
 
-Pebble.js allows you to write your *application logic* in JavaScript (which is executed on the phone with [PebbleKit JS](https://developer.pebble.com/docs/js/)). Pebble.js also includes a significant amount of C and JavaScript code that interacts with your application logic and passes messages between the phone (where the application logic takes place), and the watchapp (where the UI is displayed, and events occur).
+*Pebble.js* allows you to write your *application logic* in JavaScript (which is executed on the phone with [PebbleKit JS](https://developer.pebble.com/docs/js/)). *Pebble.js* also includes a significant amount of C and JavaScript code that interacts with your application logic and passes messages between the phone (where the application logic takes place), and the watchapp (where the UI is displayed, and events occur).
 
-The goal of Rocky.js is to include a JS runtime in Pebble's firmware, which would allow us to run JavaScript applications *directly on the watch*.
+The goal of *Rocky.js* is to include a JS runtime in Pebble's firmware, which would allow us to run JavaScript applications *directly on the watch*.
 
-# Contributing
+## Contributing
 
 We're interested in seeing what kinds of tools developers create when they have access to a browser-based and pixel-perfect Pebble, as well as how developers wrap our C-style APIs to make them more JavaScript friendly!
 
-If you create something interesting with Rocky.js, add it to the examples folder, submit a PR, and we'll take a look. This is a great opportunity to *directly* influence how Pebble approaches JavaScript documentation and API design.
+If you create something interesting with *Rocky.js*, add it to the [examples](//github.com/pebble/rockyjs/tree/master/examples) folder, submit a pull-request, and we'll take a look. This is a great opportunity to *directly* influence how Pebble approaches JavaScript documentation and API design.
 
-You can see what community members have built with Rocky.js on the [Community Examples](examples/community.html) page.
+You can see what community members have built with *Rocky.js* on the [Community Examples](examples/community.html) page.
 
-## Learn More
+### Learn More
 
-If you're interested in staying up to date with our Rocky.js development efforts, you can subscribe to our [JSApps newsletter](http://pbl.io/jsapps), and follow [@pebbledev](https://twitter.com/pebbledev) (or simply star this repo).
+If you're interested in staying up to date with our *Rocky.js* development efforts, you can subscribe to our [JSApps newsletter](http://pbl.io/jsapps), and follow [@pebbledev](https://twitter.com/pebbledev) (or simply star this repo).
 
-# Development
+## Development
 
-## Dependencies
+### Dependencies
 
-Rocky.js uses [Grunt](http://gruntjs.com) as a build system and [npm](https://www.npmjs.com) for dependency management. If you are unfamiliar with these technologies, we recommend you read their respective guides.
+*Rocky.js* uses [Grunt](http://gruntjs.com) as a build system and [npm](https://www.npmjs.com) for dependency management. If you are unfamiliar with these technologies, we recommend you read their respective guides.
 
-## Getting Started 
+### Getting Started
 
-To begin working with the Rocky.js repository, run the following commands:
+To begin working with the *Rocky.js* repository, run the following commands:
 
 ```bash
-> git clone git@github.com:pebble/rockyjs.git
-> cd rockyjs
-> npm install -g grunt-cli
-> npm install
-> grunt
+$ git clone git@github.com:pebble/rockyjs.git
+$ cd rockyjs
+$ npm install -g grunt-cli
+$ npm install
+$ grunt
 ```
 
-The default build task (`grunt`) will combine all JavaScript, render markdown, and replace file references. 
+The default build task (invoking `grunt` without arguments) will combine all JavaScript, render markdown, and replace file references.
 
-## Rocky.js API / Functionality
+### Rocky.js API / Functionality
 
-One of the main goals of Rocky.js is to better understand how JavaScript developers approach the Pebble API, and Pebble development in general. 
+One of the main goals of *Rocky.js* is to better understand how JavaScript developers approach the Pebble API, and Pebble development in general.
 
-The initial version of Rocky.js uses Pebble's existing C-style API and JavaScript syntax, though at the moment not *all* APIs are implemented.
+The initial version of *Rocky.js* uses Pebble's existing C-style API and JavaScript syntax, though at the moment *not all* APIs are implemented.
 
 See [Rocky Documentation](docs/) for more details.
 
-## Working with the Examples
+### Working with the Examples
 
 The [examples](examples/) are designed to be run directly from the file system without needing to build them, and demonstrate some of the things that can be accomplished with the current implementation.
 
 More information about each example can be found on the example's webpage.
 
-# Transpiling the Pebble Firmware
+## Transpiling the Pebble Firmware
 
 **NOTE:** If you are *not* a Pebble employee, you should ignore this section of the README. If you would like to be a Pebble employee, take a look at [Pebble's jobs page](https://pebble.com/jobs).
 
-If you have access to the [Pebble firmware repository](https://github.com/pebble/tintin), 
-make sure you build applib with `-target emscripten`.
-The default Grunt task of this repository will replace the file `src/transpiled.js` with 
-`${tintin_root}/build/applib/applib-targets/emscripten/applib.js` if it exists. 
-Run `grunt newer:uglify:applib --verbose` to debug this step if necessary (be aware that the minification task might take a while).
+If you have access to the [Pebble firmware repository](https://github.com/pebble/tintin), you can
+- build *applib* with `-target emscripten`.
+  - The default Grunt task of this repository will replace the file `src/transpiled.js` with
+`${tintin_root}/build/applib/applib-targets/emscripten/applib.js` if it exists.
+- run `grunt newer:uglify:applib --verbose` to debug the above step if necessary
 
-# LICENSE
+Be aware that the minification task might take a while.
 
-Rocky.js is licensed under the [PEBBLE JAVASCRIPT LICENSE AGREEMENT](https://github.com/pebble/rockyjs/blob/master/LICENSE).
+## LICENSE
+
+*Rocky.js* is licensed under the [PEBBLE JAVASCRIPT LICENSE AGREEMENT](https://github.com/pebble/rockyjs/blob/master/LICENSE).


### PR DESCRIPTION
I found some time over the weekend to tinker with the CSS a bit (to make it less 'pragmatic'/'bootstrappy'). I guess there's a better design coming in the future, but I really wasn't happy with the current state.

While I tried to stay away from the README, I touched it in a few places in the end (it should still work when viewed on GitHub):

- Moved the 'first step' sentence above everything else as kind of a slogan. I always found the first "weird first step" headline confusing, because the mention of the 'first step' was hidden somewhere in the first paragraph.
- Only the first `Rocky.js` headline is an H1 - everything else is H2 or smaller
- Add the more common `$` prefix for bash lines.
- Restructured the section at the bottom about how to transpile the FW
- Set `Rocky.js` and other names in italic to make them easily distinguishable from regular text
- Replace PR with 'pull-request' (although maybe that dash should be a space)
- Clarified that (`grunt`) means `grunt` without arguments

Feel free to merge or ditch it.