### PR TITLE
Community links cannot use SSL

### DIFF
--- a/examples/readme.md
+++ b/examples/readme.md
@@ -9,4 +9,4 @@ This folder contains a variety of examples designed to help you understand some 
  - [GPath](gpath/index.html) – Shows how to use APIs around `GPath`.
  - [APNG/GIF](apng/index.html) – Renders an animatd GIF/animated PNG.
  - [Text](text/index.html) – Shows how to draw text and use fonts.
- - [Community Examples](community.html) - Additional examples built by community members.
+ - [Community Examples](http://pebble.github.io/rockyjs/examples/community.html) - Additional examples built by community members.

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ We're interested in seeing what kinds of tools developers create when they have 
 
 If you create something interesting with *Rocky.js*, add it to the [examples](//github.com/pebble/rockyjs/tree/master/examples) folder, submit a pull-request, and we'll take a look. This is a great opportunity to *directly* influence how Pebble approaches JavaScript documentation and API design.
 
-You can see what community members have built with *Rocky.js* on the [Community Examples](examples/community.html) page.
+You can see what community members have built with *Rocky.js* on the [Community Examples](http://pebble.github.io/rockyjs/examples/community.html) page.
 
 ### Learn More
 


### PR DESCRIPTION
Links to community.html cannot be `https` because JSBIN won't load in mixed mode, and JSBIN needs a pro account to host links on `https`.