### PR TITLE
Force examples page to http

### DIFF
--- a/examples/community.html
+++ b/examples/community.html
@@ -9,6 +9,11 @@
   <!-- /build -->
   <link href="common/css/style.css" rel="stylesheet">
   <title>Community Examples</title>
+  <script>
+    // examples don't load on https
+    if (location.protocol == 'https:')
+      location.href = location.href.replace(/^https:/, 'http:')
+  </script>
 </head>
 <body>
 <div class="container">

--- a/examples/community.html
+++ b/examples/community.html
@@ -14,7 +14,8 @@
 <div class="container">
   <div class="page-header">
     <h1>Community Examples</h1>
-    <h3 id="https-message" class="alert alert-danger hide" role="alert">Some of the community examples won't work with <strong><em>HTTPS</em>.</strong> To fix this issue, <a href="http://pebble.github.io/rockyjs/examples/community.html">reload this page with <em>HTTP</em></a>.</h3>
+    <h3 id="https-message" class="alert alert-danger hide" role="alert">Some of the community examples won't work with <strong><em>HTTPS</em></strong>.
+      To fix this issue, <a id="https-message-link" href="http://pebble.github.io/rockyjs/examples/community.html">reload this page with <em>HTTP</em></a>.</h3>
     <p class="lead">
     Below you can find what people are building with Rocky.js.
     <a href="https://github.com/pebble/rockyjs/compare">Open a pull request</a> to share your work!
@@ -49,8 +50,13 @@
 </div>
 <script>
   // examples don't load on https
-  if (location.protocol == 'https:')
-    document.getElementById('https-message').classList.remove('hide');
+  (function(){
+    if (location.protocol == 'https:') {
+      var linkElem = document.getElementById('https-message-link');
+      linkElem.setAttribute('href', location.href.replace(/^https:/, 'http:'));
+      document.getElementById('https-message').classList.remove('hide');
+    }
+  })();
 
 </script>
 <script src="https://static.jsbin.com/js/embed.min.js?3.35.9"></script>

--- a/examples/community.html
+++ b/examples/community.html
@@ -9,16 +9,12 @@
   <!-- /build -->
   <link href="common/css/style.css" rel="stylesheet">
   <title>Community Examples</title>
-  <script>
-    // examples don't load on https
-    if (location.protocol == 'https:')
-      location.href = location.href.replace(/^https:/, 'http:')
-  </script>
 </head>
 <body>
 <div class="container">
   <div class="page-header">
     <h1>Community Examples</h1>
+    <h3 id="https-message" class="alert alert-danger hide" role="alert">Some of the community examples won't work with <strong><em>HTTPS</em>.</strong> To fix this issue, <a href="http://pebble.github.io/rockyjs/examples/community.html">reload this page with <em>HTTP</em></a>.</h3>
     <p class="lead">
     Below you can find what people are building with Rocky.js.
     <a href="https://github.com/pebble/rockyjs/compare">Open a pull request</a> to share your work!
@@ -51,6 +47,12 @@
 
 
 </div>
+<script>
+  // examples don't load on https
+  if (location.protocol == 'https:')
+    document.getElementById('https-message').classList.remove('hide');
+
+</script>
 <script src="https://static.jsbin.com/js/embed.min.js?3.35.9"></script>
 <!-- build:template
 <%= github_banner %>

--- a/examples/community.html
+++ b/examples/community.html
@@ -15,7 +15,7 @@
   <div class="page-header">
     <h1>Community Examples</h1>
     <h3 id="https-message" class="alert alert-danger hide" role="alert">Some of the community examples won't work with <strong><em>HTTPS</em></strong>.
-      To fix this issue, <a id="https-message-link" href="http://pebble.github.io/rockyjs/examples/community.html">reload this page with <em>HTTP</em></a>.</h3>
+      To fix this issue, <a id="https-message-link" href="#">reload this page with <em>HTTP</em></a>.</h3>
     <p class="lead">
     Below you can find what people are building with Rocky.js.
     <a href="https://github.com/pebble/rockyjs/compare">Open a pull request</a> to share your work!


### PR DESCRIPTION
JSBIN embed doesn't work on https, unless you have the pro version